### PR TITLE
Fixed openjfx8.deb link and small typo

### DIFF
--- a/netbeans_for_linux/index.html
+++ b/netbeans_for_linux/index.html
@@ -71,7 +71,7 @@
     <code><pre>sudo apt-get install openjfx</pre></code>
   </p>
 
-  <p>Jos sinulla on Ubuntu 18.04 tai uudempi, asenna openjfx tästä paketista: <a href="openjfx8.deb">openjfx8.deb</a>. Paketin saa asennettua joko tuplaklikkaamalla sitä tai terminaalista knolla:
+  <p>Jos sinulla on Ubuntu 18.04 tai uudempi, asenna openjfx tästä paketista: <a href="../openjfx8.deb">openjfx8.deb</a>. Paketin saa asennettua joko tuplaklikkaamalla sitä tai terminaalista komennolla:
 
   <code><pre>sudo dpkg -i openjfx8.deb</pre></code>
    </p>


### PR DESCRIPTION
openjfx8.deb is located in root of the repository

Typo: knolla -> komennolla